### PR TITLE
Fix for uniqueId cache lookup on silent and interactive handlers

### DIFF
--- a/src/ADAL.PCL/AcquireTokenInteractiveHandler.cs
+++ b/src/ADAL.PCL/AcquireTokenInteractiveHandler.cs
@@ -81,6 +81,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.UserIdentifierType = userId.Type;
             this.LoadFromCache = (tokenCache != null && parameters != null && PlatformPlugin.PlatformInformation.GetCacheLoadPolicy(parameters));
             this.SupportADFS = true;
+            this.CacheQueryData.DisplayableId = this.DisplayableId;
+            this.CacheQueryData.UniqueId = this.UniqueId;
 
             this.brokerParameters["force"] = "NO";
             if (userId != UserIdentifier.AnyUser)

--- a/src/ADAL.PCL/AcquireTokenSilentHandler.cs
+++ b/src/ADAL.PCL/AcquireTokenSilentHandler.cs
@@ -45,6 +45,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.UserIdentifierType = userId.Type;
             PlatformPlugin.BrokerHelper.PlatformParameters = parameters;    
             this.SupportADFS = true;
+            this.CacheQueryData.DisplayableId = this.DisplayableId;
+            this.CacheQueryData.UniqueId = this.UniqueId;
 
             this.brokerParameters["username"] = userId.Id;
             this.brokerParameters["username_type"] = userId.Type.ToString();

--- a/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
@@ -54,6 +54,14 @@ namespace Test.ADAL.NET.Unit
         }
 
         [TestMethod]
+        [Description("Test for TokenCache")]
+        [TestCategory("AdalDotNetUnit")]
+        public async Task TokenCacheTestUniqueIdDisplayableId()
+        {
+            await TokenCacheTests.TestUniqueIdDisplayableIdLookup(new PlatformParameters(PromptBehavior.Auto, null));
+        }
+
+        [TestMethod]
         [Description("Test for Token Cache Operations")]
         [TestCategory("AdalDotNetUnit")]
         public void TokenCacheOperationsTest()


### PR DESCRIPTION
When there are two users in the cache with the same authority, clientId, tenant but different uniqueId's or displayableId's the cache will throw a mutliple token detected exception when acquiring a token silently or using an auto or never interactive client. The reason is because the userId and displayableId are not being considered during cache lookup. This change fixes that by considering those two attribute. The added test will fail when we do not consider the userId correctly. It passes with the changes.
