### PR TITLE
[Mac] Build fixes

### DIFF
--- a/src/ADAL.PCL.Mac/BrokerHelper.cs
+++ b/src/ADAL.PCL.Mac/BrokerHelper.cs
@@ -1,0 +1,56 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Foundation;
+
+namespace Microsoft.IdentityService.Clients.ActiveDirectory
+{
+    class BrokerHelper : IBrokerHelper
+    {
+        public IPlatformParameters PlatformParameters { get; set; }
+
+        public bool CanInvokeBroker {
+            get {
+                return false;
+            }
+        }
+
+        public Task<AuthenticationResultEx> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
+        {
+            throw new InvalidOperationException("Broker not supported on Mac");
+        }
+
+        public static void SetBrokerResponse(NSUrl brokerResponse)
+        {
+            throw new InvalidOperationException("Broker not supported on Mac");
+        }
+    }
+}
+

--- a/src/ADAL.PCL.Mac/PlatformParameters.cs
+++ b/src/ADAL.PCL.Mac/PlatformParameters.cs
@@ -1,0 +1,56 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using AppKit;
+
+namespace Microsoft.IdentityService.Clients.ActiveDirectory
+{
+    /// <summary>
+    /// Additional parameters used in acquiring user's authorization
+    /// </summary>
+    public class PlatformParameters : IPlatformParameters
+    {
+        private PlatformParameters()
+        {
+        }
+
+        /// <summary>
+        /// Additional parameters used in acquiring user's authorization
+        /// </summary>
+        /// <param name="callerWindow">NSWindow instance</param>
+        public PlatformParameters(NSWindow callerWindow):this()
+        {
+            this.CallerWindow = callerWindow;
+        }
+
+        /// <summary>
+        /// Caller NSWindow
+        /// </summary>
+        public NSWindow CallerWindow { get; private set; }
+    }
+}
+

--- a/src/ADAL.PCL.iOS/WebUI.cs
+++ b/src/ADAL.PCL.iOS/WebUI.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -64,6 +64,13 @@ namespace Microsoft.IdentityService.Clients.ActiveDirectory
         {
             try
             {
+#if MAC
+                this.parameters.CallerWindow.InvokeOnMainThread(() =>
+                {
+                    var windowController = new AuthenticationAgentNSWindowController(authorizationUri.AbsoluteUri, redirectUri.OriginalString, CallbackMethod);
+                    windowController.Run(parameters.CallerWindow);
+                });
+#else
                 this.parameters.CallerViewController.InvokeOnMainThread(() =>
                 {
                     var navigationController =
@@ -71,6 +78,7 @@ namespace Microsoft.IdentityService.Clients.ActiveDirectory
                             redirectUri.OriginalString, CallbackMethod);
                     this.parameters.CallerViewController.PresentViewController(navigationController, false, null);
                 });
+#endif
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
I'm trying again to update Xamarin's stuff this week and I think I need to update this library in the process, but the current dev branch isn't building on Mac anymore. This PR is to solve that.


Restore BrokerHelper.cs and PlatformParameters.cs which seem like they got nuked during a merge here https://github.com/crmann1/azure-activedirectory-library-for-dotnet/commit/91470a2ffb4d384096a0c408e7c4939db8da44af

Fix WebUI.cs to handle Mac again, which looks like it was broken here https://github.com/crmann1/azure-activedirectory-library-for-dotnet/commit/f5b05b2078b9d0e64312f58a12ce945f7b164482