### PR TITLE
Fix window focus issue after authentication

### DIFF
--- a/src/ADAL.PCL.Mac/AuthenticationAgentNSWindowController.cs
+++ b/src/ADAL.PCL.Mac/AuthenticationAgentNSWindowController.cs
@@ -121,6 +121,11 @@ namespace Microsoft.IdentityService.Clients.ActiveDirectory
             }
 
             NSApplication.SharedApplication.EndModalSession(session);
+            if (callerWindow != null)
+            {
+                callerWindow.MakeMainWindow();
+                callerWindow.MakeKeyWindow();
+            }
         }
 
         //largely ported from azure-activedirectory-library-for-objc


### PR DESCRIPTION
After closing the authentication window, focus the caller window.
This will free the MainWindow reference in NSApplication and the
window will be effectively closed.