### PR TITLE
Add platform parameters to net standard so the correct login URIs are…

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/netstandard1.3/PlatformParameters.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/netstandard1.3/PlatformParameters.cs
@@ -32,5 +32,17 @@ namespace Microsoft.IdentityService.Clients.ActiveDirectory
     /// </summary>
     public class PlatformParameters : IPlatformParameters
     {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="promptBehavior"></param>
+        public PlatformParameters(PromptBehavior promptBehavior)
+        {
+        }
+
+        /// <summary>
+        /// Gets prompt behavior. If <see cref="PromptBehavior.Always"/>, asks service to show user the authentication page which gives them chance to authenticate as a different user.
+        /// </summary>
+        public PromptBehavior PromptBehavior { get; internal set; }
     }
 }


### PR DESCRIPTION
Allow net standard to set the platform parameters prompt enumeration. Even though in net standard there is no UI, the enum cause ADAL to generate certain login URI's based on the parameter. We need the correct URIs to be generated.