### PR TITLE
[linux] Use SolutionDir to find NuGets

### DIFF
--- a/src/ADAL.PCL.Linux/ADAL.PCL.Linux.csproj
+++ b/src/ADAL.PCL.Linux/ADAL.PCL.Linux.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Xwt.Gtk.0.2.5\build\Xwt.Gtk.props" Condition="Exists('..\..\packages\Xwt.Gtk.0.2.5\build\Xwt.Gtk.props')" />
+  <Import Project="$(SolutionDir)\packages\Xwt.Gtk.0.2.5\build\Xwt.Gtk.props" Condition="Exists('$(SolutionDir)\packages\Xwt.Gtk.0.2.5\build\Xwt.Gtk.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -35,10 +35,10 @@
     <Reference Include="System.Xml" />
     <Reference Include="Mono.Posix" />
     <Reference Include="Xwt">
-      <HintPath>..\..\packages\Xwt.0.2.5\lib\net40\Xwt.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Xwt.0.2.5\lib\net40\Xwt.dll</HintPath>
     </Reference>
     <Reference Include="Xwt.Gtk">
-      <HintPath>..\..\packages\Xwt.Gtk.0.2.5\lib\net40\Xwt.Gtk.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Xwt.Gtk.0.2.5\lib\net40\Xwt.Gtk.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This fixes the case for building either ADAL.PCL.Linux.sln from this repo, or md-addins.sln from md-addins, but will break building ADAL.PCL.Linux.csproj directly. C'est la vie.