### PR TITLE
[linux] Provide a no-parameter PlatformParameters constructor

### DIFF
--- a/src/ADAL.PCL.Linux/PlatformParameters.cs
+++ b/src/ADAL.PCL.Linux/PlatformParameters.cs
@@ -33,7 +33,7 @@ namespace Microsoft.IdentityService.Clients.ActiveDirectory
     /// </summary>
     public class PlatformParameters : IPlatformParameters
     {
-        private PlatformParameters()
+        public PlatformParameters()
         {
         }
 


### PR DESCRIPTION
We need to provide a no-constructor case as a workaround where the caller is a Gtk.Window, not a Xwt.Window (which causes constructor problems).