### PR TITLE
Make AdalHttpClient support proxy auth on the Mac.

### DIFF
--- a/src/ADAL.PCL.Mac/ADAL.PCL.Mac.csproj
+++ b/src/ADAL.PCL.Mac/ADAL.PCL.Mac.csproj
@@ -36,6 +36,7 @@
     <LinkMode></LinkMode>
     <LinkMode></LinkMode>
     <XamMacArch></XamMacArch>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -54,12 +55,14 @@
     <TlsProvider></TlsProvider>
     <LinkMode></LinkMode>
     <XamMacArch></XamMacArch>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Mac" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -101,6 +104,17 @@
       <Link>TokenCachePlugin.cs</Link>
     </Compile>
     <Compile Include="EphemeralCookieStore.cs" />
+    <Compile Include="..\ADAL.PCL.Desktop\UserPasswordCredential.cs">
+      <Link>UserPasswordCredential.cs</Link>
+    </Compile>
+    <Compile Include="..\ADAL.Common\AuthenticationContextIntegratedAuthExtensions.cs">
+      <Link>AuthenticationContextIntegratedAuthExtensions.cs</Link>
+    </Compile>
+    <Compile Include="MacHttpClientWrapper.cs" />
+    <Compile Include="MacHttpClientFactory.cs" />
+    <Compile Include="ProxyProvider.cs" />
+    <Compile Include="MacProxyCredentialProvider.cs" />
+    <Compile Include="KeyChain.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ADAL.PCL\ADAL.PCL.csproj">

--- a/src/ADAL.PCL.Mac/EphemeralCookieStore.cs
+++ b/src/ADAL.PCL.Mac/EphemeralCookieStore.cs
@@ -74,9 +74,18 @@ namespace Microsoft.IdentityService.Clients.ActiveDirectory
                     { NSHttpCookie.KeySecure, NSNumber.FromBoolean (isSecure) },
                 });
 
-                AddCookieToStorage(cookie);
+                try
+                {
+                    AddCookieToStorage(cookie);
+                }
+                catch (Exception ex)
+                {
+                    PlatformPlugin.Logger.Warning(null, string.Format("Invalid cookie for web view url: {0} document.cookies: {1}", docUrl, docCookies));
+                    PlatformPlugin.Logger.Error(null, ex);
+                }
             }
         }
+
         public void TakeCookies(NSUrlResponse response)
         {
             var httpResponse = response as NSHttpUrlResponse;
@@ -86,7 +95,15 @@ namespace Microsoft.IdentityService.Clients.ActiveDirectory
             var cookies = NSHttpCookie.CookiesWithResponseHeaderFields(httpResponse.AllHeaderFields, httpResponse.Url);
             foreach (var cookie in cookies)
             {
-                AddCookieToStorage(cookie);
+                try
+                {
+                    AddCookieToStorage(cookie);
+                }
+                catch (Exception ex)
+                {
+                    PlatformPlugin.Logger.Warning(null, string.Format("Invalid cookie for response url: {0}", httpResponse.Url));
+                    PlatformPlugin.Logger.Error(null, ex);
+                }
             }
         }
 

--- a/src/ADAL.PCL.Mac/KeyChain.cs
+++ b/src/ADAL.PCL.Mac/KeyChain.cs
@@ -1,0 +1,687 @@
+﻿// 
+// Keychain.cs
+//
+// Authors: Michael Hutchinson <mhutchinson@novell.com>
+//          Jeffrey Stedfast <jeff@xamarin.com>
+//
+// Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
+// Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+using Security;
+
+namespace Microsoft.IdentityService.Clients.ActiveDirectory
+{
+    static class Keychain
+    {
+        const string CoreFoundationLib = ObjCRuntime.Constants.CoreFoundationLibrary;
+        const string SecurityLib = ObjCRuntime.Constants.SecurityLibrary;
+
+        internal static IntPtr CurrentKeychain = IntPtr.Zero;
+
+        [DllImport(CoreFoundationLib, EntryPoint = "CFRelease")]
+        static extern void CFReleaseInternal(IntPtr cfRef);
+
+        static void CFRelease(IntPtr cfRef)
+        {
+            if (cfRef != IntPtr.Zero)
+                CFReleaseInternal(cfRef);
+        }
+
+        #region Managing Keychains
+
+        [DllImport(SecurityLib)]
+        static extern SecStatusCode SecKeychainCreate(byte[] pathName, uint passwordLength, byte[] password,
+                                                      bool promptUser, IntPtr initialAccess, out IntPtr keychain);
+
+        [DllImport(SecurityLib)]
+        static extern SecStatusCode SecKeychainDelete(IntPtr keychain);
+
+        [DllImport(SecurityLib)]
+        static extern SecStatusCode SecKeychainOpen(byte[] pathName, out IntPtr keychain);
+
+        internal static IntPtr CreateKeychain(string path, string password)
+        {
+            var passwd = Encoding.UTF8.GetBytes(password);
+
+            var status = SecKeychainCreate(path.ToNullTerminatedUtf8(), (uint)passwd.Length, passwd, false, IntPtr.Zero, out IntPtr result);
+            if (status != SecStatusCode.Success)
+                throw new Exception(status.GetStatusDescription());
+
+            return result;
+        }
+
+        internal static bool TryDeleteKeychain(string path)
+        {
+            var result = SecKeychainOpen(path.ToNullTerminatedUtf8(), out IntPtr ptr);
+            try
+            {
+                if (result == SecStatusCode.Success)
+                {
+                    DeleteKeychain(ptr);
+                    return true;
+                }
+            }
+            catch
+            {
+                // If we call 'SecKeychainOpen' on a keychain path that does not exist,
+                // we get a return value of 'success' and we also get a non-null handle.
+                // As such there's no way for the test suite to safely check if a keychain
+                // exists so it can delete a pre-existing one before exceuting. Work around
+                // this by wrapping in a try/catch. The 'DeleteKeyChain (IntPtr)' method 
+                // will throw a 'key chain does not exist' error if there is no pre-existing
+                // keychain
+            }
+            finally
+            {
+                CFRelease(ptr);
+            }
+            return false;
+        }
+
+        internal static void DeleteKeychain(IntPtr keychain)
+        {
+            var status = SecKeychainDelete(keychain);
+            if (status != SecStatusCode.Success)
+                throw new Exception(status.GetStatusDescription());
+        }
+
+        #endregion
+
+        #region Storing and Retrieving Passwords
+
+        [DllImport(SecurityLib)]
+        static extern SecStatusCode SecKeychainAddInternetPassword(IntPtr keychain, uint serverNameLength, byte[] serverName, uint securityDomainLength,
+                                                                   byte[] securityDomain, uint accountNameLength, byte[] accountName, uint pathLength,
+                                                                   byte[] path, ushort port, SecProtocolType protocol, SecAuthenticationType authType,
+                                                                   uint passwordLength, byte[] passwordData, ref IntPtr itemRef);
+        [DllImport(SecurityLib)]
+        static extern SecStatusCode SecKeychainFindInternetPassword(IntPtr keychain, uint serverNameLength, byte[] serverName, uint securityDomainLength,
+                                                                    byte[] securityDomain, uint accountNameLength, byte[] accountName, uint pathLength,
+                                                                    byte[] path, ushort port, SecProtocolType protocol, SecAuthenticationType authType,
+                                                                    out uint passwordLength, out IntPtr passwordData, ref IntPtr itemRef);
+
+        [DllImport(SecurityLib)]
+        static extern SecStatusCode SecKeychainFindInternetPassword(IntPtr keychain, uint serverNameLength, byte[] serverName, uint securityDomainLength,
+                                                                    byte[] securityDomain, uint accountNameLength, byte[] accountName, uint pathLength,
+                                                                    byte[] path, ushort port, SecProtocolType protocol, SecAuthenticationType authType,
+                                                                    IntPtr passwordLengthRef, IntPtr passwordDataRef, ref IntPtr itemRef);
+
+        [DllImport(SecurityLib)]
+        static extern SecStatusCode SecKeychainAddGenericPassword(IntPtr keychain, uint serviceNameLength, byte[] serviceName,
+                                                                  uint accountNameLength, byte[] accountName, uint passwordLength,
+                                                                  byte[] passwordData, ref IntPtr itemRef);
+        [DllImport(SecurityLib)]
+        static extern SecStatusCode SecKeychainFindGenericPassword(IntPtr keychain, uint serviceNameLength, byte[] serviceName,
+                                                                   uint accountNameLength, byte[] accountName, out uint passwordLength,
+                                                                   out IntPtr passwordData, ref IntPtr itemRef);
+
+        #endregion
+
+        #region Creating and Deleting Keychain Items
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct SecKeychainAttributeList
+        {
+            public int Count;
+            public IntPtr Attrs;
+
+            public SecKeychainAttributeList(int count, IntPtr attrs)
+            {
+                Count = count;
+                Attrs = attrs;
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct SecKeychainAttribute
+        {
+            public SecItemAttr Tag;
+            public uint Length;
+            public IntPtr Data;
+
+            public SecKeychainAttribute(SecItemAttr tag, uint length, IntPtr data)
+            {
+                Tag = tag;
+                Length = length;
+                Data = data;
+            }
+        }
+
+        [DllImport(SecurityLib)]
+        static extern unsafe SecStatusCode SecKeychainItemCreateFromContent(SecItemClass itemClass, SecKeychainAttributeList* attrList,
+                                                                            uint passwordLength, byte[] password, IntPtr keychain,
+                                                                            IntPtr initialAccess, IntPtr itemRef);
+
+        [DllImport(SecurityLib)]
+        static extern SecStatusCode SecKeychainItemDelete(IntPtr itemRef);
+
+        #endregion
+
+        #region Managing Keychain Items
+
+        [StructLayout(LayoutKind.Sequential)]
+        unsafe struct SecKeychainAttributeInfo
+        {
+            public uint Count;
+            public int* Tag;
+            public int* Format;
+        }
+
+        [DllImport(SecurityLib)]
+        static extern unsafe SecStatusCode SecKeychainItemFreeAttributesAndData(SecKeychainAttributeList* list, IntPtr data);
+
+        [DllImport(SecurityLib)]
+        static extern unsafe SecStatusCode SecKeychainItemCopyAttributesAndData(IntPtr itemRef, SecKeychainAttributeInfo* info, ref SecItemClass itemClass,
+                                                                                SecKeychainAttributeList** attrList, IntPtr lengthRef, IntPtr outDataRef);
+
+        [DllImport(SecurityLib)]
+        static extern unsafe SecStatusCode SecKeychainItemModifyAttributesAndData(IntPtr itemRef, SecKeychainAttributeList* attrList, uint length, byte[] data);
+
+        [DllImport(SecurityLib)]
+        static extern SecStatusCode SecKeychainItemCopyContent(IntPtr itemRef, ref SecItemClass itemClass, IntPtr attrList, ref uint length, ref IntPtr data);
+
+        [DllImport(SecurityLib)]
+        static extern SecStatusCode SecKeychainItemFreeContent(IntPtr attrList, IntPtr data);
+
+        #endregion
+
+        static SecAuthenticationType GetSecAuthenticationType(string query)
+        {
+            if (string.IsNullOrEmpty(query))
+                return SecAuthenticationType.Any;
+
+            string auth = "default";
+            foreach (var pair in query.Substring(1).Split(new char[] { '&' }))
+            {
+                var kvp = pair.Split(new char[] { '=' });
+                if (string.Equals(kvp[0], "auth", StringComparison.InvariantCultureIgnoreCase) && kvp.Length == 2)
+                {
+                    auth = kvp[1].ToLowerInvariant();
+                    break;
+                }
+            }
+
+            switch (auth)
+            {
+                case "ntlm": return SecAuthenticationType.NTLM;
+                case "msn": return SecAuthenticationType.MSN;
+                case "dpa": return SecAuthenticationType.DPA;
+                case "rpa": return SecAuthenticationType.RPA;
+                case "httpbasic": case "basic": return SecAuthenticationType.HTTPBasic;
+                case "httpdigest": case "digest": return SecAuthenticationType.HTTPDigest;
+                case "htmlform": case "form": return SecAuthenticationType.HTMLForm;
+                case "default": return SecAuthenticationType.Default;
+                default: return SecAuthenticationType.Any;
+            }
+        }
+
+        static SecProtocolType GetSecProtocolType(string protocol)
+        {
+            switch (protocol.ToLowerInvariant())
+            {
+                case "ftp": return SecProtocolType.FTP;
+                case "ftpaccount": return SecProtocolType.FTPAccount;
+                case "http": return SecProtocolType.HTTP;
+                case "irc": return SecProtocolType.IRC;
+                case "nntp": return SecProtocolType.NNTP;
+                case "pop3": return SecProtocolType.POP3;
+                case "smtp": return SecProtocolType.SMTP;
+                case "socks": return SecProtocolType.SOCKS;
+                case "imap": return SecProtocolType.IMAP;
+                case "ldap": return SecProtocolType.LDAP;
+                case "appletalk": return SecProtocolType.AppleTalk;
+                case "afp": return SecProtocolType.AFP;
+                case "telnet": return SecProtocolType.Telnet;
+                case "ssh": return SecProtocolType.SSH;
+                case "ftps": return SecProtocolType.FTPS;
+                case "httpproxy": return SecProtocolType.HTTPProxy;
+                case "httpsproxy": return SecProtocolType.HTTPSProxy;
+                case "ftpproxy": return SecProtocolType.FTPProxy;
+                case "cifs": return SecProtocolType.CIFS;
+                case "smb": return SecProtocolType.SMB;
+                case "rtsp": return SecProtocolType.RTSP;
+                case "rtspproxy": return SecProtocolType.RTSPProxy;
+                case "daap": return SecProtocolType.DAAP;
+                case "eppc": return SecProtocolType.EPPC;
+                case "ipp": return SecProtocolType.IPP;
+                case "nntps": return SecProtocolType.NNTPS;
+                case "ldaps": return SecProtocolType.LDAPS;
+                case "telnets": return SecProtocolType.TelnetS;
+                case "imaps": return SecProtocolType.IMAPS;
+                case "ircs": return SecProtocolType.IRCS;
+                case "pop3s": return SecProtocolType.POP3S;
+                case "cvspserver": return SecProtocolType.CVSpserver;
+                case "svn": return SecProtocolType.SVN;
+                default: return SecProtocolType.Any;
+            }
+        }
+
+        static unsafe SecStatusCode ReplaceInternetPassword(IntPtr item, byte[] desc, byte[] passwd)
+        {
+            fixed (byte* descPtr = desc)
+            {
+                SecKeychainAttribute* attrs = stackalloc SecKeychainAttribute[1];
+                int n = 0;
+
+                if (desc != null)
+                    attrs[n++] = new SecKeychainAttribute(SecItemAttr.Description, (uint)desc.Length, (IntPtr)descPtr);
+
+                SecKeychainAttributeList attrList = new SecKeychainAttributeList(n, (IntPtr)attrs);
+
+                return SecKeychainItemModifyAttributesAndData(item, &attrList, (uint)passwd.Length, passwd);
+            }
+        }
+
+        static unsafe SecStatusCode AddInternetPassword(byte[] label, byte[] desc, SecAuthenticationType auth, byte[] user, byte[] passwd, SecProtocolType protocol, byte[] host, int port, byte[] path)
+        {
+            // Note: the following code does more-or-less the same as:
+            //SecKeychainAddInternetPassword (CurrentKeychain, (uint) host.Length, host, 0, null,
+            //                                (uint) user.Length, user, (uint) path.Length, path, (ushort) port,
+            //                                protocol, auth, (uint) passwd.Length, passwd, ref item);
+
+            fixed (byte* labelPtr = label, descPtr = desc, userPtr = user, hostPtr = host, pathPtr = path)
+            {
+                SecKeychainAttribute* attrs = stackalloc SecKeychainAttribute[8];
+                int* protoPtr = (int*)&protocol;
+                int* authPtr = (int*)&auth;
+                int* portPtr = &port;
+                int n = 0;
+
+                attrs[n++] = new SecKeychainAttribute(SecItemAttr.Label, (uint)label.Length, (IntPtr)labelPtr);
+                if (desc != null)
+                    attrs[n++] = new SecKeychainAttribute(SecItemAttr.Description, (uint)desc.Length, (IntPtr)descPtr);
+                attrs[n++] = new SecKeychainAttribute(SecItemAttr.Account, (uint)user.Length, (IntPtr)userPtr);
+                attrs[n++] = new SecKeychainAttribute(SecItemAttr.Protocol, (uint)4, (IntPtr)protoPtr);
+                attrs[n++] = new SecKeychainAttribute(SecItemAttr.AuthType, (uint)4, (IntPtr)authPtr);
+                attrs[n++] = new SecKeychainAttribute(SecItemAttr.Server, (uint)host.Length, (IntPtr)hostPtr);
+                attrs[n++] = new SecKeychainAttribute(SecItemAttr.Port, (uint)4, (IntPtr)portPtr);
+                attrs[n++] = new SecKeychainAttribute(SecItemAttr.Path, (uint)path.Length, (IntPtr)pathPtr);
+
+                SecKeychainAttributeList attrList = new SecKeychainAttributeList(n, (IntPtr)attrs);
+
+                var result = SecKeychainItemCreateFromContent(SecItemClass.InternetPassword, &attrList, (uint)passwd.Length, passwd, CurrentKeychain, IntPtr.Zero, IntPtr.Zero);
+
+                return result;
+            }
+        }
+
+        public static unsafe void AddInternetPassword(Uri uri, string username, string password)
+        {
+            byte[] path = uri.ToPathBytes();
+            byte[] passwd = Encoding.UTF8.GetBytes(password);
+            byte[] host = Encoding.UTF8.GetBytes(uri.Host);
+            byte[] user = Encoding.UTF8.GetBytes(username);
+            var auth = GetSecAuthenticationType(uri.Query);
+            var protocol = GetSecProtocolType(uri.Scheme);
+            IntPtr item = IntPtr.Zero;
+            int port = uri.Port;
+            byte[] desc = null;
+
+            if (auth == SecAuthenticationType.HTMLForm)
+                desc = WebFormPassword;
+
+            // See if there is already a password there for this uri
+            var result = SecKeychainFindInternetPassword(CurrentKeychain, (uint)host.Length, host, 0, null,
+                                              (uint)user.Length, user, (uint)path.Length, path, (ushort)port,
+                                              protocol, auth, IntPtr.Zero, IntPtr.Zero, ref item);
+
+            try
+            {
+                if (result == SecStatusCode.Success)
+                {
+                    // If there is, replace it with the new one
+                    result = ReplaceInternetPassword(item, desc, passwd);
+                }
+                else
+                {
+                    var label = Encoding.UTF8.GetBytes(string.Format("{0} ({1})", uri.Host, username));
+
+                    result = AddInternetPassword(label, desc, auth, user, passwd, protocol, host, port, path);
+                }
+            }
+            finally
+            {
+                CFRelease(item);
+            }
+
+            if (result != SecStatusCode.Success && result != SecStatusCode.DuplicateItem)
+                throw new Exception("Could not add internet password to keychain: " + result.GetStatusDescription());
+        }
+
+        static readonly byte[] WebFormPassword = Encoding.UTF8.GetBytes("Web form password");
+
+        public static unsafe void AddInternetPassword(Uri uri, string password) =>
+            AddInternetPassword(uri, Uri.UnescapeDataString(uri.UserInfo), password);
+
+        static unsafe string GetUsernameFromKeychainItemRef(IntPtr itemRef)
+        {
+            int[] formatConstants = { (int)CssmDbAttributeFormat.String };
+            int[] attributeTags = { (int)SecItemAttr.Account };
+
+            fixed (int* tags = attributeTags, formats = formatConstants)
+            {
+                var attributeInfo = new SecKeychainAttributeInfo
+                {
+                    Count = 1,
+                    Tag = tags,
+                    Format = formats
+                };
+                SecKeychainAttributeList* attributeList = null;
+                SecItemClass itemClass = 0;
+
+                try
+                {
+                    SecStatusCode status = SecKeychainItemCopyAttributesAndData(itemRef, &attributeInfo, ref itemClass, &attributeList, IntPtr.Zero, IntPtr.Zero);
+
+                    if (status == SecStatusCode.ItemNotFound)
+                        throw new Exception("Could not add internet password to keychain: " + status.GetStatusDescription());
+
+                    if (status != SecStatusCode.Success)
+                        throw new Exception("Could not find internet username and password: " + status.GetStatusDescription());
+
+                    var userNameAttr = (SecKeychainAttribute*)attributeList->Attrs;
+
+                    if (userNameAttr->Length == 0)
+                        return null;
+
+                    return Marshal.PtrToStringAuto(userNameAttr->Data, (int)userNameAttr->Length);
+                }
+                finally
+                {
+                    SecKeychainItemFreeAttributesAndData(attributeList, IntPtr.Zero);
+                }
+            }
+        }
+
+        public static unsafe Tuple<string, string> FindInternetUserNameAndPassword(Uri uri)
+        {
+            var protocol = GetSecProtocolType(uri.Scheme);
+            return FindInternetUserNameAndPassword(uri, protocol);
+        }
+
+        public static unsafe Tuple<string, string> FindInternetUserNameAndPassword(Uri uri, SecProtocolType protocol)
+        {
+            byte[] path = uri.ToPathBytes();
+            byte[] host = Encoding.UTF8.GetBytes(uri.Host);
+            var auth = GetSecAuthenticationType(uri.Query);
+            IntPtr passwordData;
+            IntPtr item = IntPtr.Zero;
+            uint passwordLength = 0;
+
+            var result = SecKeychainFindInternetPassword(
+                CurrentKeychain, (uint)host.Length, host, 0, null,
+                0, null, (uint)path.Length, path, (ushort)uri.Port,
+                protocol, auth, out passwordLength, out passwordData, ref item);
+
+            try
+            {
+                if (result != SecStatusCode.Success)
+                    return null;
+
+                var username = GetUsernameFromKeychainItemRef(item);
+                return Tuple.Create(username, Marshal.PtrToStringAuto(passwordData, (int)passwordLength));
+            }
+            finally
+            {
+                SecKeychainItemFreeContent(IntPtr.Zero, passwordData);
+                CFRelease(item);
+            }
+        }
+
+        public static string FindInternetPassword(Uri uri)
+        {
+            byte[] path = uri.ToPathBytes();
+            byte[] user = Encoding.UTF8.GetBytes(Uri.UnescapeDataString(uri.UserInfo));
+            byte[] host = Encoding.UTF8.GetBytes(uri.Host);
+            var auth = GetSecAuthenticationType(uri.Query);
+            var protocol = GetSecProtocolType(uri.Scheme);
+            IntPtr passwordData = IntPtr.Zero;
+            IntPtr item = IntPtr.Zero;
+            uint passwordLength = 0;
+
+            try
+            {
+                // Look for an internet password for the given protocol and auth mechanism
+                var result = SecKeychainFindInternetPassword(CurrentKeychain, (uint)host.Length, host, 0, null,
+                                                              (uint)user.Length, user, (uint)path.Length, path, (ushort)uri.Port,
+                                                              protocol, auth, out passwordLength, out passwordData, ref item);
+
+                // Fall back to looking for a password for SecProtocolType.Any && SecAuthenticationType.Any
+                if (result == SecStatusCode.ItemNotFound && protocol != SecProtocolType.Any)
+                    result = SecKeychainFindInternetPassword(CurrentKeychain, (uint)host.Length, host, 0, null,
+                                                              (uint)user.Length, user, (uint)path.Length, path, (ushort)uri.Port,
+                                                              0, auth, out passwordLength, out passwordData, ref item);
+
+                if (result != SecStatusCode.Success)
+                    return null;
+
+                return Marshal.PtrToStringAuto(passwordData, (int)passwordLength);
+            }
+            finally
+            {
+                CFRelease(item);
+
+                SecKeychainItemFreeContent(IntPtr.Zero, passwordData);
+            }
+        }
+
+        public static void RemoveInternetPassword(Uri uri)
+        {
+            byte[] path = uri.ToPathBytes();
+            byte[] user = Encoding.UTF8.GetBytes(Uri.UnescapeDataString(uri.UserInfo));
+            byte[] host = Encoding.UTF8.GetBytes(uri.Host);
+            var auth = GetSecAuthenticationType(uri.Query);
+            var protocol = GetSecProtocolType(uri.Scheme);
+            IntPtr item = IntPtr.Zero;
+
+            // Look for an internet password for the given protocol and auth mechanism
+            var result = SecKeychainFindInternetPassword(CurrentKeychain, (uint)host.Length, host, 0, null,
+                (uint)user.Length, user, (uint)path.Length, path, (ushort)uri.Port,
+                protocol, auth, IntPtr.Zero, IntPtr.Zero, ref item);
+
+            // Fall back to looking for a password for SecProtocolType.Any && SecAuthenticationType.Any
+            if (result == SecStatusCode.ItemNotFound && protocol != SecProtocolType.Any)
+                result = SecKeychainFindInternetPassword(CurrentKeychain, (uint)host.Length, host, 0, null,
+                    (uint)user.Length, user, (uint)path.Length, path, (ushort)uri.Port,
+                    0, auth, IntPtr.Zero, IntPtr.Zero, ref item);
+
+            try
+            {
+                if (result != SecStatusCode.Success)
+                    return;
+
+                SecKeychainItemDelete(item);
+            }
+            finally
+            {
+                CFRelease(item);
+            }
+        }
+
+        public static void RemoveInternetUserNameAndPassword(Uri uri)
+        {
+            byte[] path = uri.ToPathBytes();
+            byte[] host = Encoding.UTF8.GetBytes(uri.Host);
+            var auth = GetSecAuthenticationType(uri.Query);
+            IntPtr item = IntPtr.Zero;
+
+            var result = SecKeychainFindInternetPassword(
+                CurrentKeychain, (uint)host.Length, host, 0, null,
+                0, null, (uint)path.Length, path, (ushort)uri.Port,
+                GetSecProtocolType(uri.Scheme), auth, IntPtr.Zero, IntPtr.Zero, ref item);
+
+            try
+            {
+                if (result != SecStatusCode.Success)
+                    return;
+
+                result = SecKeychainItemDelete(item);
+            }
+            finally
+            {
+                CFRelease(item);
+            }
+        }
+
+        static byte[] ToPathBytes(this Uri uri)
+        {
+            var pathStr = string.Join(string.Empty, uri.Segments);
+            byte[] path = pathStr.Length > 0 ? pathStr.ToNullTerminatedUtf8(1) : Array.Empty<byte>(); // don't include the leading '/'
+            return path;
+        }
+
+        // It seems that keychain APIs require null terminated native strings.
+        internal static byte[] ToNullTerminatedUtf8(this string str, int offset = 0)
+        {
+            unsafe
+            {
+                fixed (char* p = str)
+                {
+                    return ToNullTerminatedUtf8(p + offset, str.Length - offset);
+                }
+            }
+        }
+
+        static unsafe byte[] ToNullTerminatedUtf8(char* p, int len)
+        {
+            if (len == 0)
+                return Array.Empty<byte>();
+
+            var byteCount = Encoding.UTF8.GetByteCount(p, len);
+            var bytes = new byte[byteCount + 1];
+            fixed (byte* b = bytes)
+            {
+                Encoding.UTF8.GetBytes(p, len, b, byteCount);
+            }
+            return bytes;
+        }
+    }
+
+    enum SecItemClass : uint
+    {
+        InternetPassword = 1768842612, // 'inet'
+        GenericPassword = 1734700656, // 'genp'
+        AppleSharePassword = 1634953328, // 'ashp'
+        Certificate = 0x80000000 + 0x1000,
+        PublicKey = 0x0000000A + 5,
+        PrivateKey = 0x0000000A + 6,
+        SymmetricKey = 0x0000000A + 7
+    }
+
+    enum SecItemAttr : int
+    {
+        CreationDate = 1667522932,
+        ModDate = 1835295092,
+        Description = 1684370275,
+        Comment = 1768123764,
+        Creator = 1668445298,
+        Type = 1954115685,
+        ScriptCode = 1935897200,
+        Label = 1818321516,
+        Invisible = 1768846953,
+        Negative = 1852139361,
+        CustomIcon = 1668641641,
+        Account = 1633903476,
+        Service = 1937138533,
+        Generic = 1734700641,
+        SecurityDomain = 1935961454,
+        Server = 1936881266,
+        AuthType = 1635023216,
+        Port = 1886351988,
+        Path = 1885434984,
+        Volume = 1986817381,
+        Address = 1633969266,
+        Signature = 1936943463,
+        Protocol = 1886675820,
+        CertificateType = 1668577648,
+        CertificateEncoding = 1667591779,
+        CrlType = 1668445296,
+        CrlEncoding = 1668443747,
+        Alias = 1634494835,
+    }
+
+    enum SecAuthenticationType : int
+    {
+        NTLM = 1835824238,
+        MSN = 1634628461,
+        DPA = 1633775716,
+        RPA = 1633775730,
+        HTTPBasic = 1886680168,
+        HTTPDigest = 1685353576,
+        HTMLForm = 1836216166,
+        Default = 1953261156,
+        Any = 0
+    }
+
+    public enum SecProtocolType : int
+    {
+        FTP = 1718906912,
+        FTPAccount = 1718906977,
+        HTTP = 1752462448,
+        IRC = 1769104160,
+        NNTP = 1852732528,
+        POP3 = 1886351411,
+        SMTP = 1936553072,
+        SOCKS = 1936685088,
+        IMAP = 1768776048,
+        LDAP = 1818517872,
+        AppleTalk = 1635019883,
+        AFP = 1634103328,
+        Telnet = 1952803950,
+        SSH = 1936943136,
+        FTPS = 1718906995,
+        HTTPProxy = 1752461432,
+        HTTPSProxy = 1752462200,
+        FTPProxy = 1718907000,
+        CIFS = 1667851891,
+        SMB = 1936548384,
+        RTSP = 1920234352,
+        RTSPProxy = 1920234360,
+        DAAP = 1684103536,
+        EPPC = 1701867619,
+        IPP = 1768976416,
+        NNTPS = 1853124723,
+        LDAPS = 1818521715,
+        TelnetS = 1952803955,
+        IMAPS = 1768779891,
+        IRCS = 1769104243,
+        POP3S = 1886351475,
+        CVSpserver = 1668707184,
+        SVN = 1937141280,
+        Any = 0
+    }
+
+    enum CssmDbAttributeFormat : int
+    {
+        String = 0,
+        Int32 = 1,
+        UInt32 = 2,
+        BigNum = 3,
+        Real = 4,
+        DateTime = 5,
+        Blob = 6,
+        MultiUInt32 = 7,
+        Complex = 8
+    }
+}

--- a/src/ADAL.PCL.Mac/MacHttpClientFactory.cs
+++ b/src/ADAL.PCL.Mac/MacHttpClientFactory.cs
@@ -25,25 +25,15 @@
 //
 //------------------------------------------------------------------------------
 
-using System;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Microsoft.IdentityService.Clients.ActiveDirectory
 {
-    public class WebUIFactory : IWebUIFactory
+    class MacHttpClientFactory : IHttpClientFactory
     {
-        public WebUIFactory()
-        {
-            // HACK: The WebUIFactory is initialized after the default HttpClientFactory is created so
-            // we use the creation of the WebUIFactory to replace the default HttpClientFactory.
-            PlatformPlugin.HttpClientFactory = new MacHttpClientFactory();
-        }
+        public bool AddAdditionalHeaders { get; set; }
 
-        public IWebUI CreateAuthenticationDialog(IPlatformParameters parameters)
+        public IHttpClient Create(string uri, CallState callState)
         {
-            return new WebUI(parameters);
+            return new MacHttpClientWrapper(uri, callState);
         }
     }
 }

--- a/src/ADAL.PCL.Mac/MacHttpClientWrapper.cs
+++ b/src/ADAL.PCL.Mac/MacHttpClientWrapper.cs
@@ -1,0 +1,231 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.IdentityService.Clients.ActiveDirectory
+{
+    /// <summary>
+    /// TODO: Re-use HttpClientWrapper instead of duplicating code here. Perhaps the
+    /// HttpMessageHandlerFactory could have a way to override its default behaviour. Then
+    /// the MacHttpClientFactory could set a custom handler to create the Mac specific
+    /// NSUrlSessionHandler. However since the ServiceHub does not seem to support loading
+    /// Xamarin.Mac then another approach would be to allow the HttpClient creation to be
+    /// overridden. Then the proxy credentials for the HttpClient could be configured.
+    /// </summary>
+    class MacHttpClientWrapper : IHttpClient
+    {
+        private readonly string uri;
+        private int timeoutInMilliSeconds = 30000;
+
+        public MacHttpClientWrapper(string uri, CallState callState)
+        {
+            this.uri = uri;
+            this.Headers = new Dictionary<string, string>();
+            this.CallState = callState;
+        }
+
+        protected CallState CallState { get; set; }
+
+        public IRequestParameters BodyParameters { get; set; }
+
+        public string Accept { get; set; }
+
+        public string ContentType { get; set; }
+
+        public bool UseDefaultCredentials { get; set; }
+
+        public Dictionary<string, string> Headers { get; private set; }
+
+        public int TimeoutInMilliSeconds
+        {
+            set
+            {
+                this.timeoutInMilliSeconds = value;
+            }
+        }
+
+        public async Task<IHttpWebResponse> GetResponseAsync()
+        {
+            using (HttpClient client = new HttpClient(GetMessageHandler(this.UseDefaultCredentials)))
+            {
+                client.DefaultRequestHeaders.Accept.Clear();
+                HttpRequestMessage requestMessage = new HttpRequestMessage();
+                requestMessage.RequestUri = new Uri(uri);
+                requestMessage.Headers.Accept.Clear();
+
+                requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(this.Accept ?? "application/json"));
+                foreach (KeyValuePair<string, string> kvp in this.Headers)
+                {
+                    requestMessage.Headers.Add(kvp.Key, kvp.Value);
+                }
+
+                bool addCorrelationId = (this.CallState != null && this.CallState.CorrelationId != Guid.Empty);
+                if (addCorrelationId)
+                {
+                    requestMessage.Headers.Add(OAuthHeader.CorrelationId, this.CallState.CorrelationId.ToString());
+                    requestMessage.Headers.Add(OAuthHeader.RequestCorrelationIdInResponse, "true");
+                }
+
+                client.Timeout = TimeSpan.FromMilliseconds(this.timeoutInMilliSeconds);
+
+                HttpResponseMessage responseMessage;
+
+                try
+                {
+                    if (this.BodyParameters != null)
+                    {
+                        HttpContent content;
+                        if (this.BodyParameters is StringRequestParameters)
+                        {
+                            content = new StringContent(this.BodyParameters.ToString(), Encoding.UTF8, this.ContentType);
+                        }
+                        else
+                        {
+                            content = new FormUrlEncodedContent(((DictionaryRequestParameters)this.BodyParameters).ToList());
+                        }
+
+                        requestMessage.Method = HttpMethod.Post;
+                        requestMessage.Content = content;
+                    }
+                    else
+                    {
+                        requestMessage.Method = HttpMethod.Get;
+                    }
+
+                     responseMessage = await client.SendAsync(requestMessage).ConfigureAwait(false);
+                }
+                catch (TaskCanceledException ex)
+                {
+                    throw new HttpRequestWrapperException(null, ex);
+                }
+
+                IHttpWebResponse webResponse = await CreateResponseAsync(responseMessage).ConfigureAwait(false);
+
+                if (!responseMessage.IsSuccessStatusCode)
+                {
+                    try
+                    {
+                        throw new HttpRequestException(string.Format(CultureInfo.CurrentCulture, " Response status code does not indicate success: {0} ({1}).", (int)webResponse.StatusCode, webResponse.StatusCode), new Exception(webResponse.ResponseString));
+                    }
+                    catch (HttpRequestException ex)
+                    {
+                        throw new HttpRequestWrapperException(webResponse, ex);
+                    }
+                }
+
+                if (addCorrelationId)
+                {
+                    VerifyCorrelationIdHeaderInReponse(webResponse.Headers);
+                }
+
+                return webResponse;
+            }
+        }
+
+        public async static Task<IHttpWebResponse> CreateResponseAsync(HttpResponseMessage response)
+        {
+            var headers = new Dictionary<string, string>();
+            if (response.Headers != null)
+            {
+                foreach (var kvp in response.Headers)
+                {
+                    headers[kvp.Key] = kvp.Value.First();
+                }
+            }
+
+            return new HttpWebResponseWrapper(await response.Content.ReadAsStringAsync().ConfigureAwait(false), headers, response.StatusCode);
+        }
+
+        private void VerifyCorrelationIdHeaderInReponse(Dictionary<string, string> headers)
+        {
+            foreach (string reponseHeaderKey in headers.Keys)
+            {
+                string trimmedKey = reponseHeaderKey.Trim();
+                if (string.Compare(trimmedKey, OAuthHeader.CorrelationId, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    string correlationIdHeader = headers[trimmedKey].Trim();
+                    Guid correlationIdInResponse;
+                    if (!Guid.TryParse(correlationIdHeader, out correlationIdInResponse))
+                    {
+                        PlatformPlugin.Logger.Warning(CallState, string.Format(CultureInfo.CurrentCulture, "Returned correlation id '{0}' is not in GUID format.", correlationIdHeader));
+                    }
+                    else if (correlationIdInResponse != this.CallState.CorrelationId)
+                    {
+                        PlatformPlugin.Logger.Warning(
+                            this.CallState,
+                            string.Format(CultureInfo.CurrentCulture, "Returned correlation id '{0}' does not match the sent correlation id '{1}'", correlationIdHeader, CallState.CorrelationId));
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a HttpClientHandler and configures the proxy with credentials if they exist.
+        /// </summary>
+        internal HttpMessageHandler GetMessageHandler(bool useDefaultCredentials)
+        {
+            var handler = new HttpClientHandler { UseDefaultCredentials = useDefaultCredentials };
+
+            var requestUri = new Uri(uri);
+            var proxy = ProxyProvider.GetProxy(requestUri);
+            if (proxy != null)
+            {
+                PlatformPlugin.Logger.Information(CallState, string.Format(CultureInfo.CurrentCulture, "Proxy found for '{0}', Proxy '{1}'", uri, proxy.GetProxy(requestUri)));
+
+                handler.Proxy = proxy;
+                var credentials = MacProxyCredentialProvider.GetCredentials(requestUri, proxy);
+                if (credentials != null)
+                {
+                    PlatformPlugin.Logger.Information(CallState, string.Format(CultureInfo.CurrentCulture, "Found proxy credentials for '{0}'", uri));
+                    proxy.Credentials = credentials;
+                }
+                else
+                {
+                    PlatformPlugin.Logger.Information(CallState, string.Format(CultureInfo.CurrentCulture, "No proxy credentials found for '{0}'", uri));
+                }
+            }
+            else
+            {
+                PlatformPlugin.Logger.Information(CallState, string.Format(CultureInfo.CurrentCulture, "No proxy found for '{0}'", uri));
+             }
+
+            return handler;
+        }
+    }
+}
+

--- a/src/ADAL.PCL.Mac/MacProxyCredentialProvider.cs
+++ b/src/ADAL.PCL.Mac/MacProxyCredentialProvider.cs
@@ -1,0 +1,59 @@
+﻿//
+// MacProxyCredentialsProvider.cs
+//
+// Author:
+//       Bojan Rajkovic <bojan.rajkovic@xamarin.com>
+//
+// Copyright (c) 2013 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Net;
+
+namespace Microsoft.IdentityService.Clients.ActiveDirectory
+{
+    static class MacProxyCredentialProvider
+    {
+        public static ICredentials GetCredentials(Uri uri, IWebProxy proxy)
+        {
+            // if looking for proxy credentials, we care about the proxy's URL, not the request URL
+            var proxyUri = proxy.GetProxy(uri);
+            if (proxyUri != null)
+                uri = proxyUri;
+
+            return GetSystemProxyCredentials(uri);
+        }
+
+        static ICredentials GetSystemProxyCredentials(Uri uri)
+        {
+            var kind = SecProtocolType.Any;
+            if (uri.Scheme == "http")
+                kind = SecProtocolType.HTTPProxy;
+            else if (uri.Scheme == "https")
+                kind = SecProtocolType.HTTPSProxy;
+
+            var existing = Keychain.FindInternetUserNameAndPassword(uri, kind);
+            if (existing != null && existing.Item1 != null && existing.Item2 != null)
+                return new NetworkCredential(existing.Item1, existing.Item2);
+
+            return null;
+        }
+    }
+}

--- a/src/ADAL.PCL.Mac/ProxyProvider.cs
+++ b/src/ADAL.PCL.Mac/ProxyProvider.cs
@@ -1,0 +1,77 @@
+﻿//
+// From NuGet src/Core
+// Based on ProxyCache
+//
+// Copyright (c) 2010-2014 Outercurve Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net;
+
+namespace Microsoft.IdentityService.Clients.ActiveDirectory
+{
+    static class ProxyProvider
+    {
+        /// <summary>
+        /// Capture the default System Proxy so that it can be re-used by the IProxyFinder
+        /// because we can't rely on WebRequest.DefaultWebProxy since someone can modify the DefaultWebProxy
+        /// property and we can't tell if it was modified and if we are still using System Proxy Settings or not.
+        /// </summary>
+        static readonly IWebProxy originalSystemProxy = WebRequest.GetSystemWebProxy();
+
+        public static IWebProxy GetProxy(Uri uri)
+        {
+            if (!IsSystemProxySet(uri))
+                return null;
+
+            return GetSystemProxy(uri);
+        }
+
+        static WebProxy GetSystemProxy(Uri uri)
+        {
+            // WebRequest.DefaultWebProxy seems to be more capable in terms of getting the default
+            // proxy settings instead of the WebRequest.GetSystemProxy()
+            var proxyUri = originalSystemProxy.GetProxy(uri);
+            return new WebProxy(proxyUri);
+        }
+
+        /// <summary>
+        /// Return true or false if connecting through a proxy server
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <returns></returns>
+        static bool IsSystemProxySet(Uri uri)
+        {
+            // The reason for not calling the GetSystemProxy is because the object
+            // that will be returned is no longer going to be the proxy that is set by the settings
+            // on the users machine only the Address is going to be the same.
+            // Not sure why the .NET team did not want to expose all of the useful settings like
+            // ByPass list and other settings that we can't get because of it.
+            // Anyway the reason why we need the DefaultWebProxy is to see if the uri that we are
+            // getting the proxy for to should be bypassed or not. If it should be bypassed then
+            // return that we don't need a proxy and we should try to connect directly.
+            IWebProxy proxy = WebRequest.DefaultWebProxy;
+            if (proxy != null)
+            {
+                Uri proxyAddress = new Uri(proxy.GetProxy(uri).AbsoluteUri);
+                if (string.Equals(proxyAddress.AbsoluteUri, uri.AbsoluteUri))
+                    return false;
+                if (proxy.IsBypassed(uri))
+                    return false;
+            }
+
+            return proxy != null;
+        }
+    }
+}

--- a/src/ADAL.PCL.iOS/Logger.cs
+++ b/src/ADAL.PCL.iOS/Logger.cs
@@ -35,28 +35,24 @@ namespace Microsoft.IdentityService.Clients.ActiveDirectory
         internal override void Error(CallState callState, Exception ex, [System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "")
         {
             string message = PrepareLogMessage(callState, GetCallerFilename(callerFilePath), ex.ToString());
-            Console.WriteLine(message); //Console.writeline writes to NSLog by default
             LoggerCallbackHandler.ExecuteCallback(LogLevel.Error, message);
         }
 
         internal override void Verbose(CallState callState, string message, [System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "")
         {
             string updatedMessage = PrepareLogMessage(callState, GetCallerFilename(callerFilePath), message);
-            Console.WriteLine(updatedMessage); //Console.writeline writes to NSLog by default
             LoggerCallbackHandler.ExecuteCallback(LogLevel.Verbose, updatedMessage);
         }
 
         internal override void Information(CallState callState, string message, [System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "")
         {
             string updatedMessage = PrepareLogMessage(callState, GetCallerFilename(callerFilePath), message);
-            Console.WriteLine(updatedMessage); //Console.writeline writes to NSLog by default
             LoggerCallbackHandler.ExecuteCallback(LogLevel.Information, updatedMessage);
         }
 
         internal override void Warning(CallState callState, string message, [System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "")
         {
             string updatedMessage = PrepareLogMessage(callState, GetCallerFilename(callerFilePath), message);
-            Console.WriteLine(updatedMessage); //Console.writeline writes to NSLog by default
             LoggerCallbackHandler.ExecuteCallback(LogLevel.Warning, updatedMessage);
         }
     }


### PR DESCRIPTION
Added a custom HttpClientFactory that is proxy aware and will
look for proxy credentials stored in the Mac's key chain. This
is included in the Platform specific assembly used by IdentityService
when it is run with ServiceHub:

Microsoft.IdentityService.Clients.ActiveDirectory.Platform.dll